### PR TITLE
[JENKINS-67300] Only check tooltip size if set as parameter

### DIFF
--- a/src/main/resources/font-awesome/svg-icon.jelly
+++ b/src/main/resources/font-awesome/svg-icon.jelly
@@ -24,7 +24,7 @@
   </st:once>
 
   <j:choose>
-    <j:when test="${size(tooltip) > 0}">
+    <j:when test="${tooltip != null and size(tooltip) > 0}">
       <span class="fa-tooltip">
         <span class="jenkins-tooltip">${tooltip}</span>
         <svg class="fa-svg-icon ${class}">


### PR DESCRIPTION
Otherwise we get an exception, see [JENKINS-67300](https://issues.jenkins.io/browse/JENKINS-67300) for details.