### PR TITLE
Remove fallback for new Jenkins tooltips styling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <module.name>${project.groupId}.font-awesome-api</module.name>
 
     <plugin-util-api.version>2.13.0</plugin-util-api.version>
+    <jenkins.baseline>2.319</jenkins.baseline>
   </properties>
 
   <licenses>

--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -14,16 +14,6 @@
     top: 105%;
     left: 105%;
     width: 15em;
-
-    /* TODO: Fix for old Jenkins versions: once we are on an LTS release > 2.303 these values can be removed */
-    padding: 5px 10px;
-    border-radius: 6px;
-    background: var(--background);
-    box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.05), 0 2px 2px rgba(0, 0, 0, 0.05), 0 10px 20px rgba(0, 0, 0, 0.2);
-    color: var(--text-color);
-    font-size: 0.8rem;
-    z-index: 40;
-    overflow: hidden;
 }
 
 .fa-tooltip:hover .jenkins-tooltip {


### PR DESCRIPTION
Remove the duplicated tooltips styling since the new baseline ensures that the required CSS files are part of core now.