### PR TITLE
Make all icons available as an individual symbol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,9 @@
     <revision>6.1.2-2</revision>
     <changelist>-SNAPSHOT</changelist>
 
+    <jenkins.baseline>2.346</jenkins.baseline>
+    <jenkins.version>2.346.3</jenkins.version>
+
     <module.name>${project.groupId}.font-awesome-api</module.name>
   </properties>
 
@@ -94,6 +97,41 @@
                 </resource>
               </resources>
             </configuration>
+          </execution>
+          <execution>
+            <id>copy-icons</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/classes/images/symbols</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/node_modules/@fortawesome/fontawesome-free/svgs</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <configuration>
+              <target>
+                <replace token="path d=" value="path fill=&quot;currentColor&quot; stroke=&quot;currentColor&quot; d=" dir="${project.build.directory}/classes/images/symbols">
+                  <include name="**/*.svg" />
+                </replace>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Make all icons available as a symbol.

Icons are then exposed as `"symbol-[style-prefix]/[icon-name] plugin-font-awesome-api"`.
Allowed style prefix values are `solid`, `regular`, or `brands`. 

Note: sprites still are packaged since other plugins are using them (Boostrap).

Examples - light theme:

![Bildschirmfoto 2022-09-20 um 12 03 11](https://user-images.githubusercontent.com/503338/191229738-1eac60ac-0b0a-447e-a457-7505fcb39593.png)

Examples - dark theme:

![Bildschirmfoto 2022-09-20 um 12 03 26](https://user-images.githubusercontent.com/503338/191229774-53bc708a-e0c2-4ea0-82d4-e37eab0560a7.png)
