### PR TITLE
Use frontend-maven-plugin configuration of parent POM

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "remark-preset-lint-recommended": "6.1.3"
   },
   "scripts": {
-    "lint-md": "remark ."
+    "lint-md": "remark .",
+    "mvnbuild": "",
+    "mvntest": ""
   },
   "remarkConfig": {
     "plugins": [

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>6.10.0</version>
+    <version>6.12.0</version>
     <relativePath />
   </parent>
 
@@ -118,33 +118,6 @@
             </fileset>
           </filesets>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.13.4</version>
-        <executions>
-          <execution>
-            <id>install node and npm</id>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <nodeVersion>v18.12.0</nodeVersion>
-            </configuration>
-          </execution>
-          <execution>
-            <id>npm install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <arguments>install</arguments>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+git pull
+git push
+mvn -B clean release:prepare release:perform

--- a/src/main/java/io/jenkins/plugins/fontawesome/FontAwesomeIcons.java
+++ b/src/main/java/io/jenkins/plugins/fontawesome/FontAwesomeIcons.java
@@ -1,17 +1,29 @@
 package io.jenkins.plugins.fontawesome;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.*;
-import java.util.*;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import io.jenkins.plugins.fontawesome.SvgTag.FontAwesomeStyle;
 
 /**
  * Utility to work with icons provided by the font-awesome-api-plugin.
@@ -19,7 +31,6 @@ import java.util.stream.Stream;
  * @author strangelookingnerd
  */
 public final class FontAwesomeIcons {
-
     private static final Logger LOGGER = Logger.getLogger(FontAwesomeIcons.class.getName());
     private static final String SVG_FILE_ENDING = ".svg";
     private static final String IMAGES_SYMBOLS_PATH = "images/symbols/";
@@ -29,7 +40,9 @@ public final class FontAwesomeIcons {
     /**
      * Takes an icon name and generates an icon class name from it.
      *
-     * @param icon the icon name
+     * @param icon
+     *         the icon name
+     *
      * @return the icon class name
      */
     public static String getIconClassName(final String icon) {
@@ -39,8 +52,7 @@ public final class FontAwesomeIcons {
     /**
      * Get all available icons provided by the font-awesome-api-plugin.
      *
-     * @return a sorted map of available icons with icon name as key and the icon
-     * class name as value.
+     * @return a sorted map of available icons with icon name as key and the icon class name as value.
      */
     public static Map<String, String> getAvailableIcons() {
         return getAvailableIcons(null);
@@ -49,15 +61,17 @@ public final class FontAwesomeIcons {
     /**
      * Get all available icons provided by the font-awesome-api-plugin filtered by their style.
      *
-     * @param filter the style to filter
-     * @return a sorted map of available icons with icon name as key and the icon
-     * class name as value filtered by the given style.
+     * @param filter
+     *         the style to filter
+     *
+     * @return a sorted map of available icons with icon name as key and the icon class name as value filtered by the
+     *         given style.
      */
-    public static Map<String, String> getAvailableIcons(final SvgTag.FontAwesomeStyle filter) {
+    public static Map<String, String> getAvailableIcons(@CheckForNull final FontAwesomeStyle filter) {
         return getIconsFromClasspath(filter);
     }
 
-    private static Map<String, String> getIconsFromClasspath(final SvgTag.FontAwesomeStyle filter) {
+    private static Map<String, String> getIconsFromClasspath(@CheckForNull final FontAwesomeStyle filter) {
         try {
             Enumeration<URL> urls = FontAwesomeIcons.class.getClassLoader().getResources(IMAGES_SYMBOLS_PATH);
 
@@ -85,18 +99,24 @@ public final class FontAwesomeIcons {
         return new LinkedHashMap<>();
     }
 
-    private static Map<String, String> collectIcons(final Path path,  @CheckForNull final SvgTag.FontAwesomeStyle filter) throws IOException {
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+    private static Map<String, String> collectIcons(final Path path, @CheckForNull final FontAwesomeStyle filter)
+            throws IOException {
         Map<String, String> icons = new LinkedHashMap<>();
 
         if (path != null) {
-            try (Stream<Path> stream = filter == null ? Files.walk(path, 2) : Files.walk(path.resolve(filter.name().toLowerCase(Locale.ENGLISH)), 1)) {
-                stream.filter(icon -> icon != null && icon.getFileName() != null && StringUtils.endsWith(icon.getFileName().toString(), SVG_FILE_ENDING))
+            try (Stream<Path> stream = filter == null ? Files.walk(path, 2) : Files.walk(
+                    path.resolve(filter.name().toLowerCase(Locale.ENGLISH)), 1)) {
+                stream.filter(icon -> icon != null && icon.getFileName() != null && StringUtils.endsWith(
+                                icon.getFileName().toString(), SVG_FILE_ENDING))
                         .sorted().forEach(icon -> {
-                            if (icon.getParent() != null && icon.getParent().getFileName() != null && icon.getFileName() != null) {
-                                String iconName = icon.getParent().getFileName() + "/" + StringUtils.removeEnd(icon.getFileName().toString(), SVG_FILE_ENDING);
-                                icons.put(iconName, getIconClassName(iconName));
-                            }
-                        }
+                                    if (icon.getParent() != null && icon.getParent().getFileName() != null
+                                            && icon.getFileName() != null) {
+                                        String iconName = icon.getParent().getFileName() + "/" + StringUtils.removeEnd(
+                                                icon.getFileName().toString(), SVG_FILE_ENDING);
+                                        icons.put(iconName, getIconClassName(iconName));
+                                    }
+                                }
                         );
             }
         }
@@ -107,5 +127,4 @@ public final class FontAwesomeIcons {
     private FontAwesomeIcons() {
         // hidden
     }
-
 }

--- a/src/main/java/io/jenkins/plugins/fontawesome/FontAwesomeIcons.java
+++ b/src/main/java/io/jenkins/plugins/fontawesome/FontAwesomeIcons.java
@@ -100,13 +100,12 @@ public final class FontAwesomeIcons {
     }
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-    private static Map<String, String> collectIcons(final Path path, @CheckForNull final FontAwesomeStyle filter)
-            throws IOException {
+    private static Map<String, String> collectIcons(
+            @CheckForNull final Path path, @CheckForNull final FontAwesomeStyle filter) throws IOException {
         Map<String, String> icons = new LinkedHashMap<>();
 
         if (path != null) {
-            try (Stream<Path> stream = filter == null ? Files.walk(path, 2) : Files.walk(
-                    path.resolve(filter.name().toLowerCase(Locale.ENGLISH)), 1)) {
+            try (Stream<Path> stream = findIcons(path, filter)) {
                 stream.filter(icon -> icon != null && icon.getFileName() != null && StringUtils.endsWith(
                                 icon.getFileName().toString(), SVG_FILE_ENDING))
                         .sorted().forEach(icon -> {
@@ -122,6 +121,14 @@ public final class FontAwesomeIcons {
         }
 
         return icons;
+    }
+
+    private static Stream<Path> findIcons(final Path path, @CheckForNull final FontAwesomeStyle filter) throws IOException {
+        if (filter == null) {
+            return Files.walk(path, 2);
+        }
+
+        return Files.walk(path.resolve(filter.name().toLowerCase(Locale.ENGLISH)), 1);
     }
 
     private FontAwesomeIcons() {


### PR DESCRIPTION
NPM and Node versions are now derived from [analysis-pom](https://github.com/jenkinsci/analysis-pom-plugin/blob/master/pom.xml). `frontend-maven-plugin` configuration is now derived from [plugin-pom](https://github.com/jenkinsci/plugin-pom/blob/master/pom.xml).