### PR TITLE
Remove references to master branch and use main instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: 'GitHub CI'
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,9 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
     branches:
-      - master
       - main
   schedule:
     - cron: "32 3 * * 0"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,6 @@ name: 'Generate coverage report'
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 

--- a/.github/workflows/run-release-drafter.yml
+++ b/.github/workflows/run-release-drafter.yml
@@ -3,7 +3,6 @@ name: 'Invoke Release Drafter'
 on:
   push:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -2,7 +2,6 @@ name: Sync labels
 on:
   push:
     branches:
-      - master
       - main
     paths:
       - .github/labels.yml

--- a/README.adoc
+++ b/README.adoc
@@ -3,8 +3,8 @@
 
 = Font Awesome Jenkins Plugin
 
-image:https://ci.jenkins.io/job/Plugins/job/font-awesome-api-plugin/job/master/badge/icon?subject=Jenkins%20CI[Jenkins, link=https://ci.jenkins.io/job/Plugins/job/font-awesome-api-plugin/job/master/]
-image:https://github.com/jenkinsci/font-awesome-api-plugin/workflows/GitHub%20CI/badge.svg?branch=master[GitHub Actions, link=https://github.com/jenkinsci/font-awesome-api-plugin/actions]
+image:https://ci.jenkins.io/job/Plugins/job/font-awesome-api-plugin/job/main/badge/icon?subject=Jenkins%20CI[Jenkins, link=https://ci.jenkins.io/job/Plugins/job/font-awesome-api-plugin/job/main/]
+image:https://github.com/jenkinsci/font-awesome-api-plugin/actions/workflows/ci.yml/badge.svg?branch=main[GitHub Actions, link=https://github.com/jenkinsci/font-awesome-api-plugin/actions]
 image:https://img.shields.io/github/issues-pr/jenkinsci/font-awesome-api-plugin.svg[GitHub pull requests, link=https://github.com/jenkinsci/font-awesome-api-plugin/pulls]
 
 Provides https://fontawesome.com[Font Awesome] for Jenkins Plugins. Font Awesome has vector icons and social logos,


### PR DESCRIPTION
I noticed that there are still some references to the "master" branch that has been removed.
For the workflows this is not too important but the badges in the README were broken because of this.

### Testing done

Checked if README renders badges correctly.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```